### PR TITLE
Demoapp install

### DIFF
--- a/deploy/cassandra/templates/statefulset.yaml
+++ b/deploy/cassandra/templates/statefulset.yaml
@@ -111,6 +111,12 @@ spec:
           value: {{ default "RAC1" .Values.config.rack_name | quote }}
         - name: CASSANDRA_START_RPC
           value: {{ default "false" .Values.config.start_rpc | quote }}
+        - name: CASSANDRA_LISTEN_ADDRESS
+          value: 127.0.0.1
+        - name: CASSANDRA_BROADCAST_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/deploy/demoapp/templates/locust-master.yaml
+++ b/deploy/demoapp/templates/locust-master.yaml
@@ -69,6 +69,10 @@ spec:
               value: {{ .Values.locust.enable_time_slot_probality | quote}}
             - name: LOCUSTFILE
               value: {{ .Values.locust.locustfile }}
+            - name: TIME_SLOT_PROBABILITY
+              value: {{ .Values.locust.time_slot_probability | quote}}
+            - name: TIME_SLOT_PROBABILITY_STEP_IN_MIN
+              value: {{ .Values.locust.time_slot_probability_step_in_min | quote}}
           ports:
             - name: loc-master-web
               containerPort: 8089

--- a/deploy/demoapp/templates/locust-worker.yaml
+++ b/deploy/demoapp/templates/locust-worker.yaml
@@ -45,6 +45,10 @@ spec:
             - name: NEXT_REQUEST_MAX_WAIT_MS
               value: {{ .Values.locust.next_request_max_wait_ms | quote}}
             - name: ENABLE_TIME_SLOT_PROBABILITY
-              value: {{ .Values.locust.enable_time_slot_probality | quote}}
+              value: {{ .Values.locust.enable_time_slot_probability | quote}}
             - name: LOCUSTFILE
               value: {{ .Values.locust.locustfile }}
+            - name: TIME_SLOT_PROBABILITY
+              value: {{ .Values.locust.time_slot_probability | quote}}
+            - name: TIME_SLOT_PROBABILITY_STEP_IN_MIN
+              value: {{ .Values.locust.time_slot_probability_step_in_min | quote}}

--- a/deploy/demoapp/values.yaml
+++ b/deploy/demoapp/values.yaml
@@ -23,7 +23,9 @@ locust:
   visit_rate_follow: 10
   next_request_min_wait_ms: 1000
   next_request_max_wait_ms: 10000
-  enable_time_slot_probality: 0
+  enable_time_slot_probality: 1
+  time_slot_probability: 1.0,0.1
+  time_slot_probability_step_in_min: 30
   locustfile: locustfile.py
 
 resources:
@@ -37,3 +39,7 @@ resources:
    requests:
      cpu: 250m
      memory: 64Mi
+
+cassandra:
+  exporter:
+    enabled: true


### PR DESCRIPTION
This PR:

* Fix issue where `cassandra` pod cannot start with injected `istio-proxy`, based on the suggestion [here](https://github.com/istio/istio/issues/10053#issuecomment-519511498) and [here](https://istio.io/faq/applications/#cassandra).
* Allow configuring time slot probability for locust workload simulation.
* Enable `cassandra` prometheus exporter.

Tests:

* All pods are successfully started and injected with `istio-proxy`
```
meng@Mengs-MBP$ kubectl-awslemur get po
NAME                                  READY   STATUS    RESTARTS   AGE
cassandra-0                           3/3     Running   0          21h
cassandra-1                           3/3     Running   0          21h
cassandra-2                           3/3     Running   0          21h
locust-master-7bbb558f8c-smgdh        2/2     Running   0          18h
locust-worker-7dc647c84f-6vnj8        2/2     Running   0          18h
locust-worker-7dc647c84f-zn9pm        2/2     Running   0          18h
twitter-cass-api-65765d4fd8-7cn6t     2/2     Running   0          4h55m
twitter-cass-api-65765d4fd8-b4f5l     2/2     Running   0          4h55m
twitter-cass-api-65765d4fd8-bxp6z     2/2     Running   0          4h55m
twitter-cass-api-65765d4fd8-zq869     2/2     Running   0          4h55m
twitter-cass-friend-c5f9cdcff-9f9b4   2/2     Running   0          17h
twitter-cass-tweet-6488c6454f-4zg7p   2/2     Running   0          17h
twitter-cass-tweet-6488c6454f-5zs5n   2/2     Running   0          4h55m
twitter-cass-tweet-6488c6454f-bqksg   2/2     Running   0          17h
twitter-cass-tweet-6488c6454f-sk42w   2/2     Running   0          4h55m
twitter-cass-user-6d447bbbf4-pzzx6    2/2     Running   0          17h

```
* Kiali graph
![image](https://user-images.githubusercontent.com/10012486/81113912-f448e500-8eee-11ea-9a4a-819e122de86b.png)
