### PR TITLE
Retry connecting to Cassandra due to any Exception

### DIFF
--- a/cass_driver/cass_driver.py
+++ b/cass_driver/cass_driver.py
@@ -1,11 +1,13 @@
-import time
-import os
 import logging
-from cassandra.cluster import Cluster, NoHostAvailable
-from cassandra.policies import DCAwareRoundRobinPolicy
-import cass_queries as cstr
-import cass_conf
+import os
 import threading
+import time
+
+from cassandra.cluster import Cluster
+from cassandra.policies import DCAwareRoundRobinPolicy
+
+import cass_conf
+import cass_queries as cstr
 
 CASSANDRA_HOSTS = [os.getenv('CASSANDRA_HOST_ADDRESS', 'localhost')]
 CASSANDRA_PORT = os.getenv('CASSANDRA_PORT', 9042)
@@ -42,12 +44,13 @@ class CassandraDriver:
 
         try:
             self._create_session()
-        except NoHostAvailable as e:
+        except Exception as e:
             raise DBDriverConnectionException(e)
         self._create_table()
 
     def __del__(self):
-        self.cluster.shutdown()
+        if self.cluster is not None:
+            self.cluster.shutdown()
 
     def _get_session(self):
         self.session_idx = (self.session_idx + 1) % len(self.session_pool)


### PR DESCRIPTION
## Intention
Currently when deploying our `demoapp` using [helm](https://github.com/turbonomic/demoapp/tree/master/deploy/demoapp), `cassandra` database always takes longer to start and initialize, and the services depending on `cassandra` should keep retry connection until `cassandra` is up and running. However, I see the following error with `tweet`, `friend` and `user` services and there is no retry:

```
INFO:root:Creating driver to Cassandra cluster ['cassandra'] with keyspace maxtwitter and table maxsessiontable
Traceback (most recent call last):
  File "/user_service/user_service_grpc.py", line 14, in <module>
    user_svc = UserService()
  File "/user_service/user_service.py", line 35, in __init__
    self.db_driver = cass_driver.get_db_driver(TWITTER_KEYSPACE, TWITTER_SESSION_TABLE_NAME)
  File "/cass_driver/cass_driver.py", line 134, in get_db_driver
    return _get_db_driver(keyspace, table_name)
  File "/cass_driver/cass_driver.py", line 122, in _get_db_driver
    cass_driver = CassandraDriver(keyspace, table_name=table_name, hosts=CASSANDRA_HOSTS)
  File "/cass_driver/cass_driver.py", line 44, in __init__
    self._create_session()
  File "/cass_driver/cass_driver.py", line 58, in _create_session
    self.cluster = Cluster(
  File "cassandra/cluster.py", line 1181, in cassandra.cluster.Cluster.__init__
cassandra.UnresolvableContactPoints: {}
Exception ignored in: <function CassandraDriver.__del__ at 0x7f1041252160>
Traceback (most recent call last):
  File "/cass_driver/cass_driver.py", line 50, in __del__
    self.cluster.shutdown()
AttributeError: 'NoneType' object has no attribute 'shutdown'
```

As a result, these services fail to work even after `cassandra` is up and running. I had to kill and restart these services as a workaround which is not good.

## Solution
It turns out that we do implement retry, but only for `NoHostAvailable` exception, not for the `UnresolvableContactPoints` exception. The fix is to retry connection for any `Exception`, as there could be other types of exception such as `ValueError` or `TypeError`, etc that may cause the connection to fail.

## Test
After the fix, the retry is happening:
```
mengding@mengding-mac$ kubectl -n demoapp logs -f twitter-cass-tweet-88848455c-xqfj9
INFO:root:Logging level 20
INFO:root:Server grpc.max_connection_age_ms 5000
INFO:root:DB query timeout sec 5
INFO:root:DB query retry count 5
INFO:root:Creating driver to Cassandra cluster ['cassandra'] with keyspace maxtwitter and table maxtweettable
ERROR:root:Retry in 10 seconds to connect to DB due to connection error: {}
INFO:root:Creating driver to Cassandra cluster ['cassandra'] with keyspace maxtwitter and table maxtweettable
ERROR:root:Retry in 10 seconds to connect to DB due to connection error: {}
INFO:root:Creating driver to Cassandra cluster ['cassandra'] with keyspace maxtwitter and table maxtweettable
ERROR:root:Retry in 10 seconds to connect to DB due to connection error: {}
INFO:root:Creating driver to Cassandra cluster ['cassandra'] with keyspace maxtwitter and table maxtweettable
ERROR:root:Retry in 10 seconds to connect to DB due to connection error: {}
INFO:root:Creating driver to Cassandra cluster ['cassandra'] with keyspace maxtwitter and table maxtweettable
ERROR:root:Retry in 10 seconds to connect to DB due to connection error: {}
INFO:root:Creating driver to Cassandra cluster ['cassandra'] with keyspace maxtwitter and table maxtweettable
ERROR:root:Retry in 10 seconds to connect to DB due to connection error: {}
INFO:root:Creating driver to Cassandra cluster ['cassandra'] with keyspace maxtwitter and table maxtweettable
ERROR:root:Retry in 10 seconds to connect to DB due to connection error: {}
INFO:root:Creating driver to Cassandra cluster ['cassandra'] with keyspace maxtwitter and table maxtweettable
WARNING:cassandra.cluster:Downgrading core protocol version from 66 to 65 for 10.131.1.66:9042. To avoid this, it is best practice to explicitly set Cluster(protocol_version) to the version supported by your cluster. http://datastax.github.io/python-driver/api/cassandra/cluster.html#cassandra.cluster.Cluster.protocol_version
WARNING:cassandra.cluster:Downgrading core protocol version from 65 to 5 for 10.131.1.66:9042. To avoid this, it is best practice to explicitly set Cluster(protocol_version) to the version supported by your cluster. http://datastax.github.io/python-driver/api/cassandra/cluster.html#cassandra.cluster.Cluster.protocol_version
ERROR:cassandra.connection:Closing connection <LibevConnection(139959831034752) 10.131.1.66:9042> due to protocol error: Error from server: code=000a [Protocol error] message="Beta version of the protocol used (5/v5-beta), but USE_BETA flag is unset"
WARNING:cassandra.cluster:Downgrading core protocol version from 5 to 4 for 10.131.1.66:9042. To avoid this, it is best practice to explicitly set Cluster(protocol_version) to the version supported by your cluster. http://datastax.github.io/python-driver/api/cassandra/cluster.html#cassandra.cluster.Cluster.protocol_version
INFO:root:Keyspaces: ['system_auth', 'system_schema', 'maxtwitter', 'system_distributed', 'system', 'system_traces']
INFO:root:Keyspace maxtwitter exists...
INFO:root:Creating table maxtweettable (if not exist)
INFO:root:Created new cass driver with keyspace maxtwitter and table maxtweettable!
INFO:root:Creating GRPC server with 10 workers and grpc.max_connection_age_ms 5000
INFO:root:GRPC server for tweet service started
```
