### PR TITLE
Improvement for Cassandra deployment

### DIFF
--- a/deploy/cassandra/templates/statefulset.yaml
+++ b/deploy/cassandra/templates/statefulset.yaml
@@ -52,32 +52,6 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
       containers:
-{{- if .Values.exporter.enabled }}
-      - name: cassandra-exporter
-        image: "{{ .Values.exporter.image.repo }}:{{ .Values.exporter.image.tag }}"
-        resources:
-{{ toYaml .Values.exporter.resources | indent 10 }}
-        env:
-          - name: CASSANDRA_EXPORTER_CONFIG_listenPort
-            value: {{ .Values.exporter.port | quote }}
-          - name: JVM_OPTS
-            value: {{ .Values.exporter.jvmOpts | quote }}
-        ports:
-          - name: metrics
-            containerPort: {{ .Values.exporter.port }}
-            protocol: TCP
-          - name: jmx
-            containerPort: 5555
-        livenessProbe:
-          tcpSocket:
-            port: {{ .Values.exporter.port }}
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: {{ .Values.exporter.port }}
-          initialDelaySeconds: 20
-          timeoutSeconds: 45
-{{- end }}
       - name: {{ template "cassandra.fullname" . }}
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -171,6 +145,32 @@ spec:
             exec:
               command: ["/bin/sh", "-c", "exec nodetool decommission"]
         {{- end }}
+{{- if .Values.exporter.enabled }}
+      - name: cassandra-exporter
+        image: "{{ .Values.exporter.image.repo }}:{{ .Values.exporter.image.tag }}"
+        resources:
+{{ toYaml .Values.exporter.resources | indent 10 }}
+        env:
+          - name: CASSANDRA_EXPORTER_CONFIG_listenPort
+            value: {{ .Values.exporter.port | quote }}
+          - name: JVM_OPTS
+            value: {{ .Values.exporter.jvmOpts | quote }}
+        ports:
+          - name: metrics
+            containerPort: {{ .Values.exporter.port }}
+            protocol: TCP
+          - name: jmx
+            containerPort: 5555
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.exporter.port }}
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: {{ .Values.exporter.port }}
+          initialDelaySeconds: 20
+          timeoutSeconds: 45
+{{- end }}
       terminationGracePeriodSeconds: {{ default 30 .Values.podSettings.terminationGracePeriodSeconds }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/deploy/cassandra/values.yaml
+++ b/deploy/cassandra/values.yaml
@@ -112,7 +112,13 @@ readinessProbe:
 
 ## Additional pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-podAnnotations: {}
+podAnnotations:
+  # Enable istio metrics merging for cassandra by uncommenting the following annotations.
+  # Make sure the port matches export.port.
+  # See https://superorbital.io/journal/istio-metrics-merging/
+  #prometheus.io/port: '5556'
+  #prometheus.io/path: /metrics
+  #prometheus.io/scrape: 'true'
 
 ## Additional pod labels
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

--- a/deploy/demoapp/values.yaml
+++ b/deploy/demoapp/values.yaml
@@ -73,7 +73,7 @@ cassandra:
     ##   GKE, AWS & OpenStack)
     ##
     # storageClass: "-"
-    size: 10Gi
+    size: 30Gi
   config:
     cluster_size: 3
     seed_size: 2


### PR DESCRIPTION
This PR:

* [Set the default cassandra storage capacity to 30G](https://github.com/turbonomic/demoapp/commit/57e3d4ce7fd29cf560d67d8ac06ee1eb698d168b)
* [Enable istio metrics merging for cassandra exporter](https://github.com/turbonomic/demoapp/commit/d817f0c102ac43fb67b9945040e8f0d2f2db725d)
* [Move cassandra container spec to index 0](https://github.com/turbonomic/demoapp/commit/db7cdab99442a575747e6ec33f64714aeefc61d2)