### PR TITLE
Increase timeout of livenessProbe and readinessProbe for cassandra and cassandra-exporter

### DIFF
--- a/deploy/cassandra/templates/statefulset.yaml
+++ b/deploy/cassandra/templates/statefulset.yaml
@@ -166,12 +166,13 @@ spec:
         livenessProbe:
           tcpSocket:
             port: {{ .Values.exporter.port }}
+          timeoutSeconds: 60
         readinessProbe:
           httpGet:
             path: /metrics
             port: {{ .Values.exporter.port }}
           initialDelaySeconds: 20
-          timeoutSeconds: 45
+          timeoutSeconds: 120
 {{- end }}
       terminationGracePeriodSeconds: {{ default 30 .Values.podSettings.terminationGracePeriodSeconds }}
       {{- if .Values.image.pullSecrets }}

--- a/deploy/demoapp/values.yaml
+++ b/deploy/demoapp/values.yaml
@@ -69,6 +69,10 @@ cassandra:
     #prometheus.io/port: '5556'
     #prometheus.io/path: /metrics
     #prometheus.io/scrape: 'true'
+  livenessProbe:
+    timeoutSeconds: 120
+  readinessProbe:
+    timeoutSeconds: 120
   exporter:
     enabled: true
   persistence:


### PR DESCRIPTION
This is needed in a slow environment to prevent `cassandra` and `cassandra-exporter` from being killed.